### PR TITLE
Update Scarb.lock

### DIFF
--- a/Scarb.lock
+++ b/Scarb.lock
@@ -2,6 +2,11 @@
 version = 1
 
 [[package]]
+name = "cubit"
+version = "1.3.0"
+source = "git+https://github.com/ponderingdemocritus/cubit#82be92f4c296143bbb5721c4d7b88328925fd236"
+
+[[package]]
 name = "dojo"
 version = "0.5.0"
 source = "git+https://github.com/dojoengine/dojo?tag=v0.5.0#41a48b8082456e29d35913c0b81d71382c020b35"
@@ -18,5 +23,6 @@ source = "git+https://github.com/dojoengine/dojo?tag=v0.3.11#1e651b5d4d3b79b14a7
 name = "test_project"
 version = "0.1.0"
 dependencies = [
+ "cubit",
  "dojo",
 ]


### PR DESCRIPTION
This PR updates Scarb.lock from dependencies specified in Scarb.toml.

**Diff:**
```diff --git a/Scarb.lock b/Scarb.lock
index 4478ac3..21a8229 100644
--- a/Scarb.lock
+++ b/Scarb.lock
@@ -1,6 +1,11 @@
 # Code generated by scarb DO NOT EDIT.
 version = 1
 
+[[package]]
+name = "cubit"
+version = "1.3.0"
+source = "git+https://github.com/ponderingdemocritus/cubit#82be92f4c296143bbb5721c4d7b88328925fd236"
+
 [[package]]
 name = "dojo"
 version = "0.5.0"
@@ -18,5 +23,6 @@ source = "git+https://github.com/dojoengine/dojo?tag=v0.3.11#1e651b5d4d3b79b14a7
 name = "test_project"
 version = "0.1.0"
 dependencies = [
+ "cubit",
  "dojo",
 ]
```